### PR TITLE
Fix heading on Login page.

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -96,8 +96,7 @@ function getGoogle():void{
   return (
     <div className="mt-10 grid place-items-center">
       <h1 className="mt-10 text-3xl font-extrabold text-gray-900 dark:text-white md:text-xl lg:text-2xl">
-        <span className="bg-clip-text text-sky-700 text-transparent">Sign in</span> to
-        your account
+          Sign into your account
       </h1>
       <div className="mb-3 text-sm dark:text-white">
         Don't have an account yet?{' '}


### PR DESCRIPTION
- Remove unused span from inside h1 element
- Login now displays heading '**Sign into your account**'