### PR TITLE
Emma/connectTabOrganized

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,9 +38,9 @@ const App: React.FC = () => {
           <Route path="signup" element={user ? <DBDisplay /> : <Signup />} />
           <Route path="display" element={<DBDisplay />} />
           <Route path="test-new-query" element={<TestNewQuery />} />
+          <Route path="view-saved-queries" element={<ViewSavedQueries />} />
         </Route>
         {/* main dashboard? route does not live inside the Shared layout */}
-        <Route path="view-saved-queries" element={<ViewSavedQueries />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/DBDisplay/FeatureTab.tsx
+++ b/src/components/DBDisplay/FeatureTab.tsx
@@ -74,8 +74,9 @@ export default function FeatureTab(props: any) {
   //   (state) => state
   // );
 
-  const { schemaStore, setSchemaStore, undoHandler, redoHandler, testTab } =
-    useSchemaStore((state) => state);
+  const { schemaStore, setSchemaStore, undoHandler, redoHandler } = useSchemaStore(
+    (state) => state
+  );
   const { user, setUser } = useCredentialsStore((state: any) => state);
 
   const { setWelcome, isSchema, setDarkMode, darkMode, setDBName } = useSettingsStore(
@@ -487,7 +488,7 @@ export default function FeatureTab(props: any) {
               </div>
             </button>
 
-            <p className=" mt-4 text-slate-900 dark:text-[#f8f4eb]">Action</p>
+            <p className=" mt-4 text-slate-900 dark:text-[#f8f4eb]">Connect</p>
             <hr />
             <ul className=" space-y-0">
               <li>
@@ -519,8 +520,9 @@ export default function FeatureTab(props: any) {
                   <span className="ml-3 flex-1 whitespace-nowrap">Build Database</span>
                 </a>
               </li>
+              {/* Commented code is for Export Query Button */}
               {/* TODO: Add SAVE feature */}
-              <li>
+              {/* <li>
                 <a
                   onClick={openQueryModal}
                   className="group flex cursor-pointer items-center rounded-lg p-2 text-sm font-normal text-gray-900 hover:text-yellow-500 hover:underline  dark:text-[#f8f4eb] dark:hover:text-yellow-300 "
@@ -528,10 +530,11 @@ export default function FeatureTab(props: any) {
                   <ExportQueryIcon />
                   <span className="ml-3 flex-1 whitespace-nowrap">Export Query</span>
                 </a>
-              </li>
+              </li> */}
               <br />
-                        {/* ----------- 💙💙💙💙 Edit Tab (Build Tab) ------------------------- */}
-                        <p className="text-slate-900 dark:text-[#f8f4eb]">Edit</p>
+              {/* ----------- 💙💙💙💙 Edit Tab ------------------------- */}
+              {/* Adding a Table and its features will be going inside the Main Functionalities from Connect Tab  (STRETCH) */}
+              <p className="text-slate-900 dark:text-[#f8f4eb]">Edit</p>
               <hr />
               {isSchema ? (
                 <li>

--- a/src/pages/DBDisplay.tsx
+++ b/src/pages/DBDisplay.tsx
@@ -203,12 +203,14 @@ const DBDisplay: React.FC = () => {
           {/* m-auto = margin: auto in CSS */}
           {/* w-50%: set width to 50% of parent, flex-col: stack children vertically */}
           {welcome ? (
-            <div className="canvas-ConnectToDatabase relative right-[142px] m-auto flex w-[50%] flex-col transition-colors duration-500 dark:text-[#f8f4eb]">
-              <h3 className="text-center">Welcome to dbSpy!</h3>
-              <p className="text-center">
-                Please connect your database, upload a SQL file, or build your database
-                from scratch!
-              </p>
+            <div className="pt-20">
+              <div className="canvas-ConnectToDatabase relative right-[142px] m-auto flex w-[50%] flex-col transition-colors duration-500 dark:text-[#f8f4eb]">
+                <h3 className="text-center">Welcome to dbSpy!</h3>
+                <p className="text-center">
+                  Please connect your database, upload a SQL file, or build your database
+                  from scratch!
+                </p>
+              </div>
             </div>
           ) : // If welcome state is false, check isSchema condition
           isSchema ? (

--- a/src/pages/ViewSavedQueries.tsx
+++ b/src/pages/ViewSavedQueries.tsx
@@ -1,4 +1,4 @@
-//* this will be coming from the Sidebar, Test Button
+//* this will be coming from the sidebar(FeatureTab), Test Tab
 import React from 'react';
 
 const ViewSavedQueries = () => {


### PR DESCRIPTION
Organized the Connect Tab on FeatureTab 
Items on the Edit Tab will be moved (stretch) to render / show inside the Main Functionalities of Connect 
Pushed down the 'Welcome to dbSpy' so that it does not sit on the navbar in the display page 

